### PR TITLE
Revert "Fix Principal serde_json"

### DIFF
--- a/src/principal.rs
+++ b/src/principal.rs
@@ -378,15 +378,9 @@ mod deserialize {
 impl<'de> serde::Deserialize<'de> for Principal {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Principal, D::Error> {
         use serde::de::Error;
-        if deserializer.is_human_readable() {
-            deserializer
-                .deserialize_str(deserialize::PrincipalVisitor)
-                .map_err(D::Error::custom)
-        } else {
-            deserializer
-                .deserialize_bytes(deserialize::PrincipalVisitor)
-                .map_err(D::Error::custom)
-        }
+        deserializer
+            .deserialize_bytes(deserialize::PrincipalVisitor)
+            .map_err(D::Error::custom)
     }
 }
 
@@ -541,10 +535,7 @@ mod tests {
 
     #[test]
     fn parse_management_canister_to_text_ok() {
-        assert_eq!(
-            Principal::from_str("aaaaa-aa").unwrap().as_slice(),
-            &[0u8; 0]
-        );
+        assert_eq!(Principal::from_str("aaaaa-aa").unwrap().as_slice(), &[]);
     }
 
     #[test]
@@ -602,7 +593,7 @@ mod tests {
 
     #[cfg(feature = "serde")]
     #[test]
-    fn check_serde_cbor() {
+    fn check_serialize_deserialize() {
         let id = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
 
         // Use cbor serialization.
@@ -610,18 +601,6 @@ mod tests {
         let value = serde_cbor::from_slice(vec.as_slice()).unwrap();
 
         assert_eq!(id, value);
-    }
-
-    #[cfg(feature = "serde")]
-    #[test]
-    fn check_serde_json() {
-        let id = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-
-        // Use cbor serialization.
-        let ser = serde_json::to_string(&id).unwrap();
-        let de = serde_json::from_str::<Principal>(&ser).unwrap();
-
-        assert_eq!(id, de);
     }
 
     #[test]


### PR DESCRIPTION
This reverts commit a3339a3950825cc69cf53d37fb786b41e793088b.

The above commit seems to be the cause of internal errors when used: deserialize_str trying to deserialize a principal.

```
Caused by:
    0: input: 4449444c016c01b3c4b1f204680100_0109010400000000000001
       table: type table0 = record { 1_313_628_723 : principal }
       wire_type: principal, expect_type: principal
    1: Deserialize error: Internal error at /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/candid-0.7.3/src/de.rs:459. Please file a bug.))', /home/runner/work/agent-rs/agent-rs/main/ref-tests/src/utils.rs:96:23
```