### PR TITLE
chore: update outdated dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ base32 = "0.4.0"
 crc32fast = "1.2.0"
 hex = "0.4.3"
 sha2 = "0.9.1"
-thiserror = "1.0.20"
+thiserror = "1.0.26"
 
 [dev-dependencies]
-serde = { version = "1.0.115", features = ["derive"] }
-serde_cbor = "0.11.1"
-serde_json = "1.0.57"
+serde = { version = "1.0.127", features = ["derive"] }
+serde_cbor = "0.11.2"
+serde_json = "1.0.66"
 
 [dependencies.serde]
 version = "1.0.115"


### PR DESCRIPTION
Before:
```
$ cargo outdated -R
Name        Project  Compat   Latest   Kind         Platform
----        -------  ------   ------   ----         --------
serde       1.0.126  1.0.127  1.0.127  Normal       ---
serde_cbor  0.11.1   0.11.2   0.11.2   Development  ---
serde_json  1.0.64   1.0.66   1.0.66   Development  ---
thiserror   1.0.25   1.0.26   1.0.26   Normal       ---
```

After:
```
$ cargo outdated -R
All dependencies are up to date, yay!

```
