### PR TITLE
chore: release 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-types"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Types related to the Internet Computer Public Specification."


### PR DESCRIPTION
Updates dependencies reported by `cargo outdated`
 - thiserror
 - serde
 - serde_cbor
 - serde_json