### PR TITLE
chore: Update sha2 dep to 0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 base32 = "0.4.0"
 crc32fast = "1.3.0"
 hex = "0.4.3"
-sha2 = "0.9.8"
+sha2 = "0.10.1"
 thiserror = "1.0.30"
 
 [dev-dependencies]

--- a/src/principal.rs
+++ b/src/principal.rs
@@ -391,7 +391,10 @@ impl<'de> serde::Deserialize<'de> for Principal {
 }
 
 mod inner {
-    use sha2::{digest::generic_array::typenum::Unsigned, Digest, Sha224};
+    use sha2::{
+        digest::{generic_array::typenum::Unsigned, OutputSizeUser},
+        Sha224,
+    };
 
     /// Inner structure of a Principal. This is not meant to be public as the different classes
     /// of principals are not public.
@@ -410,7 +413,8 @@ mod inner {
     }
 
     impl PrincipalInner {
-        const HASH_LEN_IN_BYTES: usize = <<Sha224 as Digest>::OutputSize as Unsigned>::USIZE; // 28
+        const HASH_LEN_IN_BYTES: usize =
+            <<Sha224 as OutputSizeUser>::OutputSize as Unsigned>::USIZE; // 28
         const MAX_LENGTH_IN_BYTES: usize = Self::HASH_LEN_IN_BYTES + 1; // 29
 
         pub const fn new() -> Self {


### PR DESCRIPTION
Fixes SDK-266.

Not a breaking change as the public API does not reference sha2's types or traits.