### PR TITLE
fix: specify repository field so that crates.io links to it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = "Types related to the Internet Computer Public Specification."
 homepage = "https://docs.rs/ic-types"
 documentation = "https://docs.rs/ic-types"
+repository="https://github.com/dfinity/ic-types"
 license = "Apache-2.0"
 readme = "README.md"
 categories = ["api-bindings", "data-structures", "no-std"]


### PR DESCRIPTION
Otherwise one might think it comes from https://github.com/dfinity/ic/tree/master/rs/types

See https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field