### PR TITLE
fix: undo deprecate from_slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [0.4.1] - 2022-07-13
+
+### Changed
+- Remove deprecation of `Principal::from_slice`.
+
 ## [0.4.0] - 2022-07-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.1] - 2022-07-13
+## [0.4.1] - 2022-07-15
 
 ### Changed
 - Remove deprecation of `Principal::from_slice`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-types"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Types related to the Internet Computer Public Specification."

--- a/src/principal.rs
+++ b/src/principal.rs
@@ -134,10 +134,6 @@ impl Principal {
     /// # Panics
     ///
     /// Panics if the slice is longer than 29 bytes.
-    #[deprecated(
-        since = "0.4.0",
-        note = "use `Principal::try_from_slice` for better error handling"
-    )]
     pub const fn from_slice(slice: &[u8]) -> Self {
         match Self::try_from_slice(slice) {
             Ok(v) => v,


### PR DESCRIPTION
`from_slice` is still useful when creating global const value:
```rust
pub const MAINNET_LEDGER_CANISTER_ID: Principal =
    Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x01, 0x01]);
```
`try_from_slice` needs `unwrap()` which is not allowed here.